### PR TITLE
fix: createJobResponseSchema internalId as nullable

### DIFF
--- a/src/schemas/core/job.schema.ts
+++ b/src/schemas/core/job.schema.ts
@@ -23,7 +23,7 @@ export const createJobResponseSchema = <T, P>(
     percentage: z.number(),
     isCleaned: z.boolean(),
     priority: z.number(),
-    internalId: z.string().optional(),
+    internalId: z.string().optional().nullable(),
     producerName: z.string().optional().nullable(),
     productName: z.string().optional(),
     productType: z.string().optional(),


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
internalId in job zod schema can be null
