### PR TITLE
chore: add copy script to package.json for package publishing process

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "lint:fix": "eslint --fix .",
     "prebuild": "npm run clean",
     "build": "tsc --project tsconfig.build.json",
+    "copy": "npm run copy:yaml",
+    "copy:yaml": "copyfiles -u 1 \"./src/openapi/**/*.yaml\" ./dist",
     "start": "npm run build && cd dist && node ./index.js",
     "clean": "rimraf dist",
-    "prepack": "npm run build",
+    "prepack": "npm run build && npm run copy",
     "prepare": "husky",
     "release": "standard-version"
   },


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

currently the openapi dir is not included when packing
introducing a npm run script that copies the openapi to a dir that is packed