### PR TITLE
ci: add resource copying step to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,8 @@ jobs:
         uses: ./.github/actions/init-npm
         with:
           node-version: 20.x
+      - name: Copy resources
+        run: npm run copy
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

add a step in publish action that runs npm copy script, to copy all relevant files to a destination dir. in order for it  to be included in the published npm package.