### PR TITLE
refactor: use artifact from @map-colonies/types instead of @map-colonies/export-interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
-        "@map-colonies/export-interfaces": "^1.5.0",
         "@map-colonies/mc-priority-queue": "^8.2.1",
-        "@map-colonies/types": "^1.3.5",
+        "@map-colonies/types": "^1.4.0",
         "geojson": "^0.5.0",
         "standard-version": "^9.5.0",
         "zod": "^3.24.1"
@@ -3430,15 +3429,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@map-colonies/export-interfaces": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/export-interfaces/-/export-interfaces-1.5.0.tgz",
-      "integrity": "sha512-r0PZ4HtYk6io9jjTxoL7JgZRuGG//SKm7dFQ1XMITSQmZu80w/qyTnftFO7VGUzPJ5Vh1hnc6zgmI6+LSv7Rtg==",
-      "peerDependencies": {
-        "@map-colonies/types": "^1.2.1",
-        "@turf/turf": "^6.5.0"
-      }
-    },
     "node_modules/@map-colonies/js-logger": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@map-colonies/js-logger/-/js-logger-1.1.0.tgz",
@@ -3496,9 +3486,9 @@
       }
     },
     "node_modules/@map-colonies/types": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@map-colonies/types/-/types-1.3.5.tgz",
-      "integrity": "sha512-FLPn+EeWj+Me96o+uY2PauCA+FM9haRqVmHnvNOspapJk51orMuuizhMnYVcnHonwlsUHmwuBr9hdv/xoUaRlA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/types/-/types-1.4.0.tgz",
+      "integrity": "sha512-BguxuTIJLzj4us5Xw0m5ZoxpktN9MQX9LNPhhnQFBjY1ExnHjZRncmprc/hE8FzvRRuLojU51JeXBmucV7gUiw==",
       "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.16",

--- a/package.json
+++ b/package.json
@@ -66,9 +66,8 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@map-colonies/export-interfaces": "^1.5.0",
     "@map-colonies/mc-priority-queue": "^8.2.1",
-    "@map-colonies/types": "^1.3.5",
+    "@map-colonies/types": "^1.4.0",
     "geojson": "^0.5.0",
     "standard-version": "^9.5.0",
     "zod": "^3.24.1"

--- a/src/schemas/export/export.schema.ts
+++ b/src/schemas/export/export.schema.ts
@@ -1,6 +1,6 @@
 import { z, ZodType } from 'zod';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
-import { Artifact } from '@map-colonies/export-interfaces';
+import { Artifact } from '@map-colonies/types';
 import { ExportArtifactType } from '../../constants/export/constants';
 import { multiPolygonSchema, polygonSchema } from '../core';
 import { CORE_VALIDATIONS } from '../../constants';

--- a/src/schemas/export/index.ts
+++ b/src/schemas/export/index.ts
@@ -1,2 +1,3 @@
 export * from './export.schema';
 export * from './job.schema';
+export * from './task.schema';

--- a/src/schemas/export/task.schema.ts
+++ b/src/schemas/export/task.schema.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+
+export const exportFinalizeTaskParamsSchema = z
+  .object({
+    gpkgModified: z.boolean(),
+    gpkgUploadedToS3: z.boolean().optional(),
+    callbacksSent: z.boolean(),
+  })
+  .describe('exportFinalizeTaskParamsSchema');

--- a/src/types/export/export.type.ts
+++ b/src/types/export/export.type.ts
@@ -3,7 +3,6 @@ import type { Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson'
 import { callbackUrlSchema, callbackUrlsArraySchema, exportAdditionalParamsSchema, exportInputParamsSchema } from '../../schemas/export/job.schema';
 import {
   artifactsArraySchema,
-  artifactSchema,
   callbackExportResponseSchema,
   cleanupDataSchema,
   fileNamesTemplatesSchema,

--- a/src/types/export/export.type.ts
+++ b/src/types/export/export.type.ts
@@ -20,5 +20,4 @@ export type CallbackExportResponse = z.infer<typeof callbackExportResponseSchema
 export type LinksDefinition = z.infer<typeof fileNamesTemplatesSchema>;
 export type ExportInputParams = z.infer<typeof exportInputParamsSchema>;
 export type ExportAdditionalParams = z.infer<typeof exportAdditionalParamsSchema>;
-export type Artifact = z.infer<typeof artifactSchema>;
 export type ArtifactsArray = z.infer<typeof artifactsArraySchema>;


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
|Refactor        |✔

