### PR TITLE
fix: removed unnecessary type import

### DIFF
--- a/src/types/ingestion/types.ts
+++ b/src/types/ingestion/types.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 import { inputFilesSchema } from '../../schemas/ingestion/inputFiles.schema';
-import { partSchema, polygonPartsEntityNameSchema, type polygonPartsPayloadSchema } from '../../schemas/ingestion/polygonParts.schema';
+import { partSchema, polygonPartsEntityNameSchema, polygonPartsPayloadSchema } from '../../schemas/ingestion/polygonParts.schema';
 import { aggregationMetadataSchema, newRasterLayerMetadataSchema, updateRasterLayerMetadataSchema } from '../../schemas/ingestion/metadata.schema';
 import { layerDataSchema, newRasterLayerRequestSchema, updateRasterLayerRequestSchema } from '../../schemas/ingestion/ingestionRequest.schema';
 import {


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

removed unnecessary type import for schema 