### PR TITLE
refactor: remove status discriminatedUnion from exportFinalizeTaskParamsSchema

### DIFF
--- a/src/schemas/export/task.schema.ts
+++ b/src/schemas/export/task.schema.ts
@@ -1,19 +1,9 @@
-import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import z from 'zod';
 
 export const exportFinalizeTaskParamsSchema = z
-  .discriminatedUnion('status', [
-    // Schema when status is Failed
-    z.object({
-      status: z.literal(OperationStatus.FAILED),
-      callbacksSent: z.boolean(),
-    }),
-    // Schema when status is Completed
-    z.object({
-      status: z.literal(OperationStatus.COMPLETED),
-      gpkgModified: z.boolean(),
-      gpkgUploadedToS3: z.boolean(),
-      callbacksSent: z.boolean(),
-    }),
-  ])
+  .object({
+    gpkgModified: z.boolean(),
+    gpkgUploadedToS3: z.boolean(),
+    callbacksSent: z.boolean(),
+  })
   .describe('exportFinalizeTaskParamsSchema');


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
remove status discriminatedUnion from exportFinalizeTaskParamsSchema(remove failed finalize)
