### PR TITLE
refactor: exportFinalizeTaskParams: use discriminatedUnion to classify different finalize tasks

### DIFF
--- a/src/constants/export/constants.ts
+++ b/src/constants/export/constants.ts
@@ -22,5 +22,5 @@ export const ExportFinalizeType = {
 
 export type TileFormatStrategy = (typeof TileFormatStrategy)[keyof typeof TileFormatStrategy];
 export type SourceType = (typeof SourceType)[keyof typeof SourceType];
-
+export type ExportFinalizeType = (typeof ExportFinalizeType)[keyof typeof ExportFinalizeType];
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/src/constants/export/constants.ts
+++ b/src/constants/export/constants.ts
@@ -15,6 +15,11 @@ export const SourceType = {
   FS: 'FS',
 } as const;
 
+export const ExportFinalizeType = {
+  Full_Processing: 'FullProcessing',
+  Error_Callback: 'ErrorCallback',
+};
+
 export type TileFormatStrategy = (typeof TileFormatStrategy)[keyof typeof TileFormatStrategy];
 export type SourceType = (typeof SourceType)[keyof typeof SourceType];
 

--- a/src/schemas/export/task.schema.ts
+++ b/src/schemas/export/task.schema.ts
@@ -1,9 +1,19 @@
 import z from 'zod';
+import { ExportFinalizeType } from '../../constants';
 
-export const exportFinalizeTaskParamsSchema = z
-  .object({
-    gpkgModified: z.boolean(),
-    gpkgUploadedToS3: z.boolean(),
-    callbacksSent: z.boolean(),
-  })
-  .describe('exportFinalizeTaskParamsSchema');
+export const exportFinalizeFullProcessingParamsSchema = z.object({
+  type: z.literal(ExportFinalizeType.Full_Processing),
+  gpkgModified: z.boolean(),
+  gpkgUploadedToS3: z.boolean(),
+  callbacksSent: z.boolean(),
+});
+
+export const exportFinalizeErrorCallbackParamsSchema = z.object({
+  type: z.literal(ExportFinalizeType.Error_Callback),
+  callbacksSent: z.boolean(),
+});
+
+export const exportFinalizeTaskParamsSchema = z.discriminatedUnion('type', [
+  exportFinalizeFullProcessingParamsSchema,
+  exportFinalizeErrorCallbackParamsSchema,
+]);

--- a/src/types/export/index.ts
+++ b/src/types/export/index.ts
@@ -1,2 +1,3 @@
 export * from './job.type';
 export * from './export.type';
+export * from './task.type';

--- a/src/types/export/task.type.ts
+++ b/src/types/export/task.type.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+import { exportFinalizeFullProcessingParamsSchema, exportFinalizeTaskParamsSchema } from '../../schemas';
+
+export type ExportFinalizeTaskParamsSchema = z.infer<typeof exportFinalizeTaskParamsSchema>;
+export type ExportFinalizeFullProcessingParamsSchema = z.infer<typeof exportFinalizeFullProcessingParamsSchema>;
+export type ExportFinalizeErrorCallbackParamsSchema = z.infer<typeof exportFinalizeTaskParamsSchema>;

--- a/src/types/export/task.type.ts
+++ b/src/types/export/task.type.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 import { exportFinalizeFullProcessingParamsSchema, exportFinalizeTaskParamsSchema } from '../../schemas';
 
-export type ExportFinalizeTaskParamsSchema = z.infer<typeof exportFinalizeTaskParamsSchema>;
-export type ExportFinalizeFullProcessingParamsSchema = z.infer<typeof exportFinalizeFullProcessingParamsSchema>;
-export type ExportFinalizeErrorCallbackParamsSchema = z.infer<typeof exportFinalizeTaskParamsSchema>;
+export type ExportFinalizeTaskParams = z.infer<typeof exportFinalizeTaskParamsSchema>;
+export type ExportFinalizeFullProcessingParams = z.infer<typeof exportFinalizeFullProcessingParamsSchema>;
+export type ExportFinalizeErrorCallbackParams = z.infer<typeof exportFinalizeTaskParamsSchema>;


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

