### PR TITLE
Feat/map-layer-name

### DIFF
--- a/src/utils/layer.utils.ts
+++ b/src/utils/layer.utils.ts
@@ -1,8 +1,13 @@
 import { RasterProductTypes } from '../constants';
 import { polygonPartsEntityPatternSchema } from '../schemas';
-import { PolygonPartsEntityName } from '../types';
+import type { PolygonPartsEntityName, LayerName } from '../types';
 
 export function generateEntityName(productId: string, productType: RasterProductTypes): PolygonPartsEntityName {
   const entityName = [productId, productType].join('_').toLowerCase();
   return polygonPartsEntityPatternSchema.parse(entityName);
+}
+
+export function getMapServingLayerName(productId: string, productType: RasterProductTypes): LayerName {
+  const layerName = `${productId}-${productType}` satisfies LayerName;
+  return layerName;
 }

--- a/src/utils/layer.utils.ts
+++ b/src/utils/layer.utils.ts
@@ -2,7 +2,7 @@ import { RasterProductTypes } from '../constants';
 import { polygonPartsEntityPatternSchema } from '../schemas';
 import type { PolygonPartsEntityName, LayerName } from '../types';
 
-export function generateEntityName(productId: string, productType: RasterProductTypes): PolygonPartsEntityName {
+export function getEntityName(productId: string, productType: RasterProductTypes): PolygonPartsEntityName {
   const entityName = [productId, productType].join('_').toLowerCase();
   return polygonPartsEntityPatternSchema.parse(entityName);
 }


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

* new function `getMapServingLayerName`, returns served layer name
* modified function name from `generateEntityName` to `getEntityName`