### PR TITLE
refactor!: change polygon part validation error to new format (MAPCO-10506)

### DIFF
--- a/src/schemas/ingestion/validationTask.schema.ts
+++ b/src/schemas/ingestion/validationTask.schema.ts
@@ -22,6 +22,7 @@ export const thresholdsSchema = z.object({
     count: counterSchema,
   }),
   smallGeometries: thresholdCheckSchema.describe('Small geometries threshold check result'),
+  resolution: thresholdCheckSchema.describe('Resolution threshold check result'),
 });
 
 export const validationAggregatedErrorsSchema = z.object({

--- a/src/types/ingestion/report.type.ts
+++ b/src/types/ingestion/report.type.ts
@@ -7,6 +7,15 @@ export type PolygonPartValidationErrorsType = Pick<
   'RESOLUTION' | 'GEOMETRY_VALIDITY' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'
 >[keyof Pick<typeof ValidationErrorType, 'GEOMETRY_VALIDITY' | 'RESOLUTION' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'>];
 
+export type PolygonPartValidationErrorItem =
+  | {
+      code: (typeof ValidationErrorType)['RESOLUTION'];
+      isExceeded: boolean;
+    }
+  | {
+      code: Exclude<PolygonPartValidationErrorsType, (typeof ValidationErrorType)['RESOLUTION']>;
+    };
+
 export interface PolygonPartValidationError {
   id: string;
   errors: PolygonPartValidationErrorsType[];

--- a/src/types/ingestion/report.type.ts
+++ b/src/types/ingestion/report.type.ts
@@ -18,7 +18,7 @@ export type PolygonPartValidationErrorItem =
 
 export interface PolygonPartValidationError {
   id: string;
-  errors: PolygonPartValidationErrorsType[];
+  errors: PolygonPartValidationErrorItem[];
 }
 export interface PolygonPartsChunkValidationResult {
   parts: PolygonPartValidationError[];

--- a/src/types/ingestion/report.type.ts
+++ b/src/types/ingestion/report.type.ts
@@ -7,14 +7,16 @@ export type PolygonPartValidationErrorsType = Pick<
   'RESOLUTION' | 'GEOMETRY_VALIDITY' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'
 >[keyof Pick<typeof ValidationErrorType, 'GEOMETRY_VALIDITY' | 'RESOLUTION' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'>];
 
-export type PolygonPartValidationErrorItem =
-  | {
-      code: (typeof ValidationErrorType)['RESOLUTION'];
-      isExceeded: boolean;
-    }
-  | {
-      code: Exclude<PolygonPartValidationErrorsType, (typeof ValidationErrorType)['RESOLUTION']>;
-    };
+export type PolygonPartValidationResolutionErrorItem = {
+  code: (typeof ValidationErrorType)['RESOLUTION'];
+  isExceeded: boolean;
+};
+
+export type PolygonPartValidationGeneralErrorItem = {
+  code: Exclude<PolygonPartValidationErrorsType, (typeof ValidationErrorType)['RESOLUTION']>;
+};
+
+export type PolygonPartValidationErrorItem = PolygonPartValidationResolutionErrorItem | PolygonPartValidationGeneralErrorItem;
 
 export interface PolygonPartValidationError {
   id: string;

--- a/src/types/ingestion/report.type.ts
+++ b/src/types/ingestion/report.type.ts
@@ -7,14 +7,14 @@ export type PolygonPartValidationErrorsType = Pick<
   'RESOLUTION' | 'GEOMETRY_VALIDITY' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'
 >[keyof Pick<typeof ValidationErrorType, 'GEOMETRY_VALIDITY' | 'RESOLUTION' | 'SMALL_GEOMETRY' | 'SMALL_HOLES' | 'UNKNOWN'>];
 
-export type PolygonPartValidationResolutionErrorItem = {
+export interface PolygonPartValidationResolutionErrorItem {
   code: (typeof ValidationErrorType)['RESOLUTION'];
   isExceeded: boolean;
-};
+}
 
-export type PolygonPartValidationGeneralErrorItem = {
+export interface PolygonPartValidationGeneralErrorItem {
   code: Exclude<PolygonPartValidationErrorsType, (typeof ValidationErrorType)['RESOLUTION']>;
-};
+}
 
 export type PolygonPartValidationErrorItem = PolygonPartValidationResolutionErrorItem | PolygonPartValidationGeneralErrorItem;
 


### PR DESCRIPTION
Update polygon part validation error to new structure.
Old:
```
"errors": ["SmallHoles", "Resolution"]
```
New:
```
"errors": [
  {"code": "Resolution", "isExceeded": true},
  {"code": "SmallHoles"}
]
```

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |