### PR TITLE
feat: add tile deletion schemas and types, refactor source type

### DIFF
--- a/src/constants/core/constants.ts
+++ b/src/constants/core/constants.ts
@@ -54,3 +54,15 @@ export const CORE_VALIDATIONS = {
 
 export const HASH_ALGORITHMS = ['XXH64'] as const;
 export type HashAlgorithm = (typeof HASH_ALGORITHMS)[number];
+
+export const MAX_ZOOM_LEVEL = 22;
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export const SourceType = {
+  S3: 'S3',
+  GPKG: 'GPKG',
+  FS: 'FS',
+} as const;
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export type SourceType = (typeof SourceType)[keyof typeof SourceType];

--- a/src/constants/export/constants.ts
+++ b/src/constants/export/constants.ts
@@ -9,18 +9,11 @@ export const TileFormatStrategy = {
   MIXED: 'mixed',
 } as const;
 
-export const SourceType = {
-  S3: 'S3',
-  GPKG: 'GPKG',
-  FS: 'FS',
-} as const;
-
 export const ExportFinalizeType = {
   Full_Processing: 'FullProcessing',
   Error_Callback: 'ErrorCallback',
 } as const;
 
 export type TileFormatStrategy = (typeof TileFormatStrategy)[keyof typeof TileFormatStrategy];
-export type SourceType = (typeof SourceType)[keyof typeof SourceType];
 export type ExportFinalizeType = (typeof ExportFinalizeType)[keyof typeof ExportFinalizeType];
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -19,7 +19,7 @@ export const tilesDeletionParamsBaseSchema = z.object({
 });
 
 export const s3TilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
-  provider: z.literal(SourceType.S3),
+  sourceProvider: z.literal(SourceType.S3),
 });
 
 export const fsTilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { MAX_ZOOM_LEVEL, SourceType, TileOutputFormat } from '../../constants';
+
+export const tileRangeSchema = z.object({
+  zoom: z.number().int().min(0).max(MAX_ZOOM_LEVEL),
+  minX: z.number().int().min(0),
+  maxX: z.number().int().min(0),
+  minY: z.number().int().min(0),
+  maxY: z.number().int().min(0),
+});
+
+export const tilesDeletionParamsBaseSchema = z.object({
+  tilesPath: z.string().min(1), // Base path for the tiles to be deleted
+  ranges: z.array(tileRangeSchema).min(1), // Array of tile ranges to be deleted
+  fileExtension: z
+    .literal(TileOutputFormat.PNG)
+    .transform((val) => val.toLowerCase())
+    .or(z.literal(TileOutputFormat.JPEG).transform((val) => val.toLowerCase())), // File extension of the tiles (e.g., 'png', 'jpeg')
+});
+
+export const s3TilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
+  provider: z.literal(SourceType.S3),
+});
+
+export const fsTilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
+  provider: z.literal(SourceType.FS),
+});
+
+export const tilesDeletionParamsSchema = z.discriminatedUnion('provider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema]);

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -23,7 +23,7 @@ export const s3TilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend(
 });
 
 export const fsTilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
-  provider: z.literal(SourceType.FS),
+  sourceProvider: z.literal(SourceType.FS),
 });
 
 export const tilesDeletionParamsSchema = z.discriminatedUnion('provider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema]);

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -26,4 +26,4 @@ export const fsTilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend(
   sourceProvider: z.literal(SourceType.FS),
 });
 
-export const tilesDeletionParamsSchema = z.discriminatedUnion('provider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema]);
+export const tilesDeletionParamsSchema = z.discriminatedUnion('sourceProvider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema]);

--- a/src/types/core/tile.type.ts
+++ b/src/types/core/tile.type.ts
@@ -1,0 +1,5 @@
+import z from 'zod';
+import { tileRangeSchema, tilesDeletionParamsSchema } from '../../schemas/core/tile.schema';
+
+export type TilesDeletionParams = z.infer<typeof tilesDeletionParamsSchema>;
+export type TileRange = z.infer<typeof tileRangeSchema>;


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| New feature     | ✔                                                                      | |


Further  information:

This pull request introduces new tile deletion parameter schemas and types, and refactors the `SourceType` constant and type to the core constants module for better consistency and reuse. The main changes focus on schema validation for tile deletion operations and code organization.

**Schema and Type Additions:**

* Added `tileRangeSchema`, `tilesDeletionParamsBaseSchema`, and provider-specific schemas (`s3TilesDeletionParamsSchema`, `fsTilesDeletionParamsSchema`) using `zod` for validating tile deletion parameters in `src/schemas/core/tile.schema.ts`.
* Introduced TypeScript types `TilesDeletionParams` and `TileRange` inferred from the new schemas in `src/types/core/tile.type.ts`.

**Constants Refactoring:**

* Moved the `SourceType` constant and type definition from `src/constants/export/constants.ts` to `src/constants/core/constants.ts` for centralized usage and maintainability [[1]](diffhunk://#diff-0b1dfc87ff6a24764f452c6bda9d13cf00c3d8c28d04673616738d2438eec4a9L12-L24) [[2]](diffhunk://#diff-50263d6a0fdbeb55245b1a772cffa5509a61eb91d817e164ab449f7c3c4fb24bR57-R68).
* Added `MAX_ZOOM_LEVEL` constant to `src/constants/core/constants.ts` for use in tile validation.