### PR TITLE
fix: update productId pattern

### DIFF
--- a/src/constants/ingestion/constants.ts
+++ b/src/constants/ingestion/constants.ts
@@ -49,7 +49,7 @@ export const INGESTION_VALIDATIONS = {
     max: 4000,
   },
   productId: {
-    pattern: '^[A-Za-z]{1}[A-Za-z0-9_]{0,37}$',
+    pattern: '^[A-Za-z]{1}[A-Za-z0-9_]{0,36}$',
     description: 'Product ID must start with a letter and contain only letters, numbers and underscores',
   },
   productVersion: {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

sync `productId` char limit to correlate with internal changes of `polygonPartsEntityName`.
the internal tables of polygon parts now support `_history` suffix which is longer than the previously max suffix length (`_parts`)