### PR TITLE
feat: add layer deletion schemas, types and constants (MAPCO-7285)

### DIFF
--- a/src/constants/deletion/constants.ts
+++ b/src/constants/deletion/constants.ts
@@ -7,7 +7,7 @@ export type DeletionJobTypes = (typeof DeletionJobTypes)[keyof typeof DeletionJo
 
 export const DeletionTaskTypes = {
   Delete: 'delete',
-  LayerTilesDeletion: 'full-layer-tiles-deletion',
+  LayerTilesDeletion: 'tiles-deletion',
   ArtifactsDeletion: 'artifacts-deletion',
 } as const;
 

--- a/src/constants/deletion/constants.ts
+++ b/src/constants/deletion/constants.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export const DeletionJobTypes = {
+  Delete_Layer: 'Delete_Layer',
+} as const;
+
+export type DeletionJobTypes = (typeof DeletionJobTypes)[keyof typeof DeletionJobTypes];
+
+export const DeletionTaskTypes = {
+  Delete: 'delete',
+  LayerTilesDeletion: 'full-layer-tiles-deletion',
+  ArtifactsDeletion: 'artifacts-deletion',
+} as const;
+
+export type DeletionTaskTypes = (typeof DeletionTaskTypes)[keyof typeof DeletionTaskTypes];
+/* eslint-enable @typescript-eslint/naming-convention */

--- a/src/constants/deletion/index.ts
+++ b/src/constants/deletion/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './core';
 export * from './ingestion';
 export * from './export';
+export * from './deletion';

--- a/src/schemas/deletion/index.ts
+++ b/src/schemas/deletion/index.ts
@@ -1,0 +1,2 @@
+export * from './task.schema';
+export * from './job.schema';

--- a/src/schemas/deletion/job.schema.ts
+++ b/src/schemas/deletion/job.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const deleteLayerJobParamsSchema = z
+  .object({
+    approver: z.string(),
+  })
+  .describe('deleteLayerJobParamsSchema');

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -6,8 +6,9 @@ export const sourceProviderSchema = z.union([z.literal(SourceType.S3), z.literal
 export const deleteTaskParamsSchema = z
   .object({
     deleteFromCatalog: z.boolean().default(false),
-    deleteFromGeoserver: z.boolean().default(false),
     deleteFromMapproxy: z.boolean().default(false),
+    deleteFromGeoserver: z.boolean().default(false),
+    deletePolygonParts: z.boolean().default(false),
   })
   .describe('deleteTaskParamsSchema');
 

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -12,16 +12,19 @@ export const deleteTaskParamsSchema = z
   })
   .describe('deleteTaskParamsSchema');
 
-export const layerTilesDeletionParamsSchema = z
-  .object({
+export const deletionParamsBaseSchema = z.object({
+  sourceProvider: sourceProviderSchema,
+  bucket: z.string().optional(),
+});
+
+export const layerTilesDeletionParamsSchema = deletionParamsBaseSchema
+  .extend({
     catalogId: z.string().uuid(),
-    sourceProvider: sourceProviderSchema,
   })
   .describe('layerTilesDeletionParamsSchema');
 
-export const artifactsDeletionParamsSchema = z
-  .object({
-    sourceProvider: sourceProviderSchema,
+export const artifactsDeletionParamsSchema = deletionParamsBaseSchema
+  .extend({
     paths: z.array(z.string().min(1)).min(1), // explicit thumbnail/legend object keys (s3) or file paths (fs)
   })
   .describe('artifactsDeletionParamsSchema');

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { SourceType } from '../../constants/core/constants';
+
+export const sourceProviderSchema = z.union([z.literal(SourceType.S3), z.literal(SourceType.FS)]);
+
+export const deleteTaskParamsSchema = z
+  .object({
+    deleteFromCatalog: z.boolean().default(false),
+    deleteFromGeoserver: z.boolean().default(false),
+    deleteFromMapproxy: z.boolean().default(false),
+  })
+  .describe('deleteTaskParamsSchema');
+
+export const layerTilesDeletionParamsSchema = z
+  .object({
+    catalogId: z.string().uuid(),
+    sourceProvider: sourceProviderSchema,
+  })
+  .describe('layerTilesDeletionParamsSchema');
+
+export const artifactsDeletionParamsSchema = z
+  .object({
+    sourceProvider: sourceProviderSchema,
+    paths: z.array(z.string().min(1)).min(1), // explicit thumbnail/legend object keys (s3) or file paths (fs)
+  })
+  .describe('artifactsDeletionParamsSchema');

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './core';
 export * from './ingestion';
 export * from './export';
+export * from './deletion';

--- a/src/types/deletion/index.ts
+++ b/src/types/deletion/index.ts
@@ -1,0 +1,2 @@
+export * from './task.type';
+export * from './job.type';

--- a/src/types/deletion/job.type.ts
+++ b/src/types/deletion/job.type.ts
@@ -1,0 +1,4 @@
+import z from 'zod';
+import { deleteLayerJobParamsSchema } from '../../schemas/deletion/job.schema';
+
+export type DeleteLayerJobParams = z.infer<typeof deleteLayerJobParamsSchema>;

--- a/src/types/deletion/task.type.ts
+++ b/src/types/deletion/task.type.ts
@@ -1,0 +1,6 @@
+import z from 'zod';
+import { deleteTaskParamsSchema, layerTilesDeletionParamsSchema, artifactsDeletionParamsSchema } from '../../schemas/deletion/task.schema';
+
+export type DeleteTaskParams = z.infer<typeof deleteTaskParamsSchema>;
+export type LayerTilesDeletionParams = z.infer<typeof layerTilesDeletionParamsSchema>;
+export type ArtifactsDeletionParams = z.infer<typeof artifactsDeletionParamsSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './core';
 export * from './ingestion';
 export * from './export';
+export * from './deletion';


### PR DESCRIPTION
| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖      |
| New feature     | ✔      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✖      |
| Chore           | ✖      |

Related issues: MAPCO-7285

Further information:

Adds the shared `deletion` module for the **layer deletion** feature, exported from the `constants`, `schemas` and `types` barrels.

- **Constants** — `DeletionJobTypes` (`Delete_Layer`) and `DeletionTaskTypes` (`delete`, `full-layer-tiles-deletion`, `artifacts-deletion`).
- **Schemas** — `deleteLayerJobParamsSchema`, `deleteTaskParamsSchema`, `layerTilesDeletionParamsSchema`, `artifactsDeletionParamsSchema` (and the shared `sourceProviderSchema` over the existing core `SourceType`).
- **Types** — `DeleteLayerJobParams`, `DeleteTaskParams`, `LayerTilesDeletionParams`, `ArtifactsDeletionParams` inferred from the schemas.



> **Base branch:** targets `alpha` (the `8.3.0-alpha.x` prerelease line for this epic), not `master`. The published `latest` version stays at `8.2.0` while the epic is in progress.
