### PR TITLE
feat!: consolidate storage schemas and add Redis provider (MAPCO-11262)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,3 +51,40 @@ jobs:
         with:
           name: Test Reporters ${{ matrix.node }}
           path: ./reports/**
+
+  upload_package:
+    needs: [eslint, tests]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out TS Project Git repository
+        uses: actions/checkout@v6
+      - name: Init nodejs
+        uses: ./.github/actions/init-npm
+
+      - name: Pack the package
+        run: npm pack
+      - name: get properties
+        id: json_properties
+        uses: ActionsTools/read-json-action@main
+        with:
+          file_path: 'package.json'
+      - uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az storage blob upload --name raster-shared-${{ github.sha }}.tgz --account-name ghatmpstorage --container-name=npm-packages --file map-colonies-raster-shared-${{steps.json_properties.outputs.version}}.tgz --sas-token "${{ secrets.SAS_TOKEN }}"
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Hi it is me, your friendly bot helper! :wave:
+            I've packed this commit for you :blush:
+            You can install it like this:
+            ```json
+            {
+              "dependencies": {
+                  "@map-colonies/raster-shared": "https://ghatmpstorage.blob.core.windows.net/npm-packages/raster-shared-${{ github.sha }}.tgz"
+              }
+            }
+            ```
+            The link will expire in a week :hourglass:          

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: ./.github/actions/init-npm
         with:
           node-version: ${{ matrix.node }}
-
       - name: Run TS Project linters
         uses: wearerequired/lint-action@v2
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -87,4 +87,4 @@ jobs:
               }
             }
             ```
-            The link will expire in a week :hourglass:          
+            The link will expire in a week :hourglass:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - name: Check out TS Project Git repository
         uses: actions/checkout@v4
-
       - name: Init nodejs
         uses: ./.github/actions/init-npm
         with:
@@ -39,13 +38,10 @@ jobs:
     steps:
       - name: Check out TS Project Git repository
         uses: actions/checkout@v4
-
       - name: Init nodejs
         uses: ./.github/actions/init-npm
-
       - name: Run tests
         run: npm run test
-
       - uses: actions/upload-artifact@v4
         with:
           name: Test Reporters ${{ matrix.node }}
@@ -60,7 +56,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Init nodejs
         uses: ./.github/actions/init-npm
-
       - name: Pack the package
         run: npm pack
       - name: get properties

--- a/src/constants/core/constants.ts
+++ b/src/constants/core/constants.ts
@@ -68,6 +68,15 @@ export const SourceType = {
 export type SourceType = (typeof SourceType)[keyof typeof SourceType];
 
 /* eslint-disable @typescript-eslint/naming-convention */
+export const StorageProvider = {
+  ...pickEnum(SourceType, ['FS', 'S3']),
+  REDIS: 'REDIS',
+} as const;
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export type StorageProvider = (typeof StorageProvider)[keyof typeof StorageProvider];
+
+/* eslint-disable @typescript-eslint/naming-convention */
 export const InstanceType = {
   INGESTION: 'ingestion',
   EXPORT: 'export',

--- a/src/constants/deletion/constants.ts
+++ b/src/constants/deletion/constants.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 export const DeletionJobTypes = {
   Delete_Layer: 'Delete_Layer',
+  Cache_Deletion: 'Cache_Deletion',
 } as const;
 
 export type DeletionJobTypes = (typeof DeletionJobTypes)[keyof typeof DeletionJobTypes];
@@ -9,7 +10,7 @@ export const DeletionTaskTypes = {
   Delete: 'delete',
   LayerTilesDeletion: 'tiles-deletion',
   ArtifactsDeletion: 'artifacts-deletion',
+  CacheDeletion: 'cache-deletion',
 } as const;
 
 export type DeletionTaskTypes = (typeof DeletionTaskTypes)[keyof typeof DeletionTaskTypes];
-/* eslint-enable @typescript-eslint/naming-convention */

--- a/src/constants/deletion/constants.ts
+++ b/src/constants/deletion/constants.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 export const DeletionJobTypes = {
   Delete_Layer: 'Delete_Layer',
-  Cache_Deletion: 'Cache_Deletion',
+  Delete_Cache: 'Delete_Cache',
 } as const;
 
 export type DeletionJobTypes = (typeof DeletionJobTypes)[keyof typeof DeletionJobTypes];

--- a/src/constants/export/constants.ts
+++ b/src/constants/export/constants.ts
@@ -1,5 +1,5 @@
 import { ArtifactRasterType } from '@map-colonies/types';
-import { pickEnum } from '../../utils';
+import { pickEnum } from '../../utils/helpers.utils';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export const ExportArtifactType = pickEnum(ArtifactRasterType, ['GPKG', 'METADATA']);

--- a/src/schemas/core/storage.schema.ts
+++ b/src/schemas/core/storage.schema.ts
@@ -1,14 +1,34 @@
 import { z } from 'zod';
-import { SourceType } from '../../constants/core/constants';
+import { StorageProvider } from '../../constants/core/constants';
 
-export const fsStorageSchema = z.object({
-  storageProvider: z.literal(SourceType.FS),
-  subPath: z.string().min(1),
-});
-
-export const s3StorageSchema = z.object({
-  storageProvider: z.literal(SourceType.S3),
+export const s3BucketSchema = z.object({
   bucket: z.string().min(1),
 });
 
-export const storageSchema = z.discriminatedUnion('storageProvider', [fsStorageSchema, s3StorageSchema]);
+export const redisPrefixSchema = z.object({
+  prefix: z.string().min(1), // Full Redis key prefix, e.g. `myLayer-redis_WorldCRS84`
+});
+
+export const fsSubPathSchema = z.object({
+  subPath: z.string().min(1),
+});
+
+export const fsStorageSchema = z
+  .object({
+    storageProvider: z.literal(StorageProvider.FS),
+  })
+  .merge(fsSubPathSchema);
+
+export const s3StorageSchema = z
+  .object({
+    storageProvider: z.literal(StorageProvider.S3),
+  })
+  .merge(s3BucketSchema);
+
+export const redisStorageSchema = z
+  .object({
+    storageProvider: z.literal(StorageProvider.REDIS),
+  })
+  .merge(redisPrefixSchema);
+
+export const storageSchema = z.discriminatedUnion('storageProvider', [fsStorageSchema, s3StorageSchema, redisStorageSchema]);

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { MAX_ZOOM_LEVEL, SourceType, TileOutputFormat } from '../../constants';
+import { MAX_ZOOM_LEVEL, TileOutputFormat } from '../../constants/core/constants';
 
 export const tileRangeSchema = z.object({
   zoom: z.number().int().min(0).max(MAX_ZOOM_LEVEL),
@@ -9,18 +9,12 @@ export const tileRangeSchema = z.object({
   maxY: z.number().int().min(0),
 });
 
-export const tilesDeletionParamsBaseSchema = z.object({
-  tilesPath: z.string().min(1), // Base path for the tiles to be deleted
+export const tileRangesSchema = z.object({
   ranges: z.array(tileRangeSchema).min(1), // Array of tile ranges to be deleted
-  fileExtension: z.literal(TileOutputFormat.PNG.toLowerCase()).or(z.literal(TileOutputFormat.JPEG.toLowerCase())), // File extension of the tiles (e.g., 'png', 'jpeg')
 });
 
-export const s3TilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
-  sourceProvider: z.literal(SourceType.S3),
+/** Fields that only make sense for path-based tile stores. */
+export const tilePyramidSchema = z.object({
+  tilesPath: z.string().min(1), // Base path for the tiles to be deleted
+  fileExtension: z.literal(TileOutputFormat.PNG.toLowerCase()).or(z.literal(TileOutputFormat.JPEG.toLowerCase())), // e.g. 'png', 'jpeg'
 });
-
-export const fsTilesDeletionParamsSchema = tilesDeletionParamsBaseSchema.extend({
-  sourceProvider: z.literal(SourceType.FS),
-});
-
-export const tilesDeletionParamsSchema = z.discriminatedUnion('sourceProvider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema]);

--- a/src/schemas/core/tile.schema.ts
+++ b/src/schemas/core/tile.schema.ts
@@ -14,7 +14,9 @@ export const tileRangesSchema = z.object({
 });
 
 /** Fields that only make sense for path-based tile stores. */
-export const tilePyramidSchema = z.object({
-  tilesPath: z.string().min(1), // Base path for the tiles to be deleted
+export const tilesInfoSchema = z.object({
+  tilesRelativePath: z.string().min(1), // Base path for the tiles to be deleted
   fileExtension: z.literal(TileOutputFormat.PNG.toLowerCase()).or(z.literal(TileOutputFormat.JPEG.toLowerCase())), // e.g. 'png', 'jpeg'
 });
+
+export const tilePyramidSchema = tileRangesSchema.merge(tilesInfoSchema).describe('tilePyramidSchema');

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -42,8 +42,7 @@ export const s3DeleteStoredResourcesParamsSchema = s3StorageSchema.merge(resourc
 
 export const fsDeleteStoredResourcesParamsSchema = fsStorageSchema.merge(resourcePathsSchema);
 
-// The prefix IS the locator for a key-value store, so `paths` is meaningless here
-// and is rejected outright rather than silently stripped.
+// The prefix IS the locator for a key-value store.
 export const redisDeleteStoredResourcesParamsSchema = redisDeletionBaseSchema.strict();
 
 export const deleteStoredResourcesParamsSchema = z

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { StorageProvider } from '../../constants/core/constants';
 import { fsStorageSchema, redisStorageSchema, s3StorageSchema } from '../core/storage.schema';
 import { tilePyramidSchema, tileRangesSchema } from '../core/tile.schema';
 
@@ -23,16 +22,9 @@ export const deleteTaskParamsSchema = z
 //#endregion DeleteTaskParams
 
 //#region TilesDeletionParams
-export const s3TilesDeletionParamsSchema = s3StorageSchema.merge(tilePyramidSchema).merge(tileRangesSchema);
+export const s3TilesDeletionParamsSchema = s3StorageSchema.merge(tilePyramidSchema);
 
-// Unlike the other providers this does NOT extend fsStorageSchema: tile deletion
-// locates tiles by `tilesPath`, not by the layer's `subPath`.
-export const fsTilesDeletionParamsSchema = z
-  .object({
-    storageProvider: z.literal(StorageProvider.FS),
-  })
-  .merge(tilePyramidSchema)
-  .merge(tileRangesSchema);
+export const fsTilesDeletionParamsSchema = fsStorageSchema.merge(tilePyramidSchema);
 
 export const redisTilesDeletionParamsSchema = redisDeletionBaseSchema.merge(tileRangesSchema).strict(); // Reject path-store fields outright: a prefix store has no tilesPath
 
@@ -42,7 +34,7 @@ export const tilesDeletionParamsSchema = z
 //#endregion TilesDeletionParams
 
 //#region DeleteStoredResourcesParams
-/** Paths to delete recursively. Meaningful only for path-based stores. */
+/** Paths to delete recursively. */
 export const resourcePathsSchema = z.object({
   paths: z.array(z.string().min(1)).min(1),
 });

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -3,6 +3,14 @@ import { StorageProvider } from '../../constants/core/constants';
 import { fsStorageSchema, redisStorageSchema, s3StorageSchema } from '../core/storage.schema';
 import { tilePyramidSchema, tileRangesSchema } from '../core/tile.schema';
 
+/**
+ * Shared by every Redis deletion shape: the key prefix that locates the entries, plus an
+ * optional wait for a mapproxy reload to settle before the keys are removed.
+ */
+const redisDeletionBaseSchema = redisStorageSchema.extend({
+  delaySeconds: z.number().int().nonnegative().optional(),
+});
+
 //#region DeleteTaskParams
 export const deleteTaskParamsSchema = z
   .object({
@@ -26,12 +34,7 @@ export const fsTilesDeletionParamsSchema = z
   .merge(tilePyramidSchema)
   .merge(tileRangesSchema);
 
-export const redisTilesDeletionParamsSchema = redisStorageSchema
-  .extend({
-    delaySeconds: z.number().int().nonnegative().optional(), // Seconds to wait before deleting(mapproxy reload delay)
-  })
-  .merge(tileRangesSchema)
-  .strict(); // Reject path-store fields outright: a prefix store has no tilesPath
+export const redisTilesDeletionParamsSchema = redisDeletionBaseSchema.merge(tileRangesSchema).strict(); // Reject path-store fields outright: a prefix store has no tilesPath
 
 export const tilesDeletionParamsSchema = z.discriminatedUnion('storageProvider', [
   s3TilesDeletionParamsSchema,
@@ -52,11 +55,7 @@ export const fsDeleteStoredResourcesParamsSchema = fsStorageSchema.merge(resourc
 
 // The prefix IS the locator for a key-value store, so `paths` is meaningless here
 // and is rejected outright rather than silently stripped.
-export const redisDeleteStoredResourcesParamsSchema = redisStorageSchema
-  .extend({
-    delaySeconds: z.number().int().nonnegative().optional(), // Seconds to wait before deleting
-  })
-  .strict();
+export const redisDeleteStoredResourcesParamsSchema = redisDeletionBaseSchema.strict();
 
 export const deleteStoredResourcesParamsSchema = z
   .discriminatedUnion('storageProvider', [

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -36,11 +36,9 @@ export const fsTilesDeletionParamsSchema = z
 
 export const redisTilesDeletionParamsSchema = redisDeletionBaseSchema.merge(tileRangesSchema).strict(); // Reject path-store fields outright: a prefix store has no tilesPath
 
-export const tilesDeletionParamsSchema = z.discriminatedUnion('storageProvider', [
-  s3TilesDeletionParamsSchema,
-  fsTilesDeletionParamsSchema,
-  redisTilesDeletionParamsSchema,
-]);
+export const tilesDeletionParamsSchema = z
+  .discriminatedUnion('storageProvider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema, redisTilesDeletionParamsSchema])
+  .describe('tilesDeletionParamsSchema');
 //#endregion TilesDeletionParams
 
 //#region DeleteStoredResourcesParams

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
-import { storageSchema } from '../core';
+import { StorageProvider } from '../../constants/core/constants';
+import { fsStorageSchema, redisStorageSchema, s3StorageSchema } from '../core/storage.schema';
+import { tilePyramidSchema, tileRangesSchema } from '../core/tile.schema';
 
+//#region DeleteTaskParams
 export const deleteTaskParamsSchema = z
   .object({
     deleteFromCatalog: z.boolean().default(false),
@@ -9,11 +12,70 @@ export const deleteTaskParamsSchema = z
     deletePolygonParts: z.boolean().default(false),
   })
   .describe('deleteTaskParamsSchema');
+//#endregion DeleteTaskParams
 
-export const deleteStoredResourcesParamsBaseSchema = z.object({
+//#region TilesDeletionParams
+export const s3TilesDeletionParamsSchema = s3StorageSchema.merge(tilePyramidSchema).merge(tileRangesSchema);
+
+// Unlike the other providers this does NOT extend fsStorageSchema: tile deletion
+// locates tiles by `tilesPath`, not by the layer's `subPath`.
+export const fsTilesDeletionParamsSchema = z
+  .object({
+    storageProvider: z.literal(StorageProvider.FS),
+  })
+  .merge(tilePyramidSchema)
+  .merge(tileRangesSchema);
+
+export const redisTilesDeletionParamsSchema = redisStorageSchema
+  .extend({
+    delaySeconds: z.number().int().nonnegative().optional(), // Seconds to wait before deleting(mapproxy reload delay)
+  })
+  .merge(tileRangesSchema)
+  .strict(); // Reject path-store fields outright: a prefix store has no tilesPath
+
+export const tilesDeletionParamsSchema = z.discriminatedUnion('storageProvider', [
+  s3TilesDeletionParamsSchema,
+  fsTilesDeletionParamsSchema,
+  redisTilesDeletionParamsSchema,
+]);
+//#endregion TilesDeletionParams
+
+//#region DeleteStoredResourcesParams
+/** Paths to delete recursively. Meaningful only for path-based stores. */
+export const resourcePathsSchema = z.object({
   paths: z.array(z.string().min(1)).min(1),
 });
 
-export const deleteStoredResourcesParamsSchema = deleteStoredResourcesParamsBaseSchema
-  .and(storageSchema)
+export const s3DeleteStoredResourcesParamsSchema = s3StorageSchema.merge(resourcePathsSchema);
+
+export const fsDeleteStoredResourcesParamsSchema = fsStorageSchema.merge(resourcePathsSchema);
+
+// The prefix IS the locator for a key-value store, so `paths` is meaningless here
+// and is rejected outright rather than silently stripped.
+export const redisDeleteStoredResourcesParamsSchema = redisStorageSchema
+  .extend({
+    delaySeconds: z.number().int().nonnegative().optional(), // Seconds to wait before deleting
+  })
+  .strict();
+
+export const deleteStoredResourcesParamsSchema = z
+  .discriminatedUnion('storageProvider', [
+    s3DeleteStoredResourcesParamsSchema,
+    fsDeleteStoredResourcesParamsSchema,
+    redisDeleteStoredResourcesParamsSchema,
+  ])
   .describe('deleteStoredResourcesParamsSchema');
+//#endregion DeleteStoredResourcesParams
+
+//#region CacheDeletionParams
+/**
+ * Params of the single `cache-deletion` task. The two shapes are told apart by their
+ * fields rather than by the task type: `ranges` present means range-based deletion,
+ * `prefix` alone means a whole-layer wipe. Both members are `.strict()`, so at most
+ * one can ever match — `ranges` is required on the first and rejected as an unknown
+ * key by the second.
+ */
+export const redisCacheDeletionParamsSchema = z
+  .union([redisTilesDeletionParamsSchema, redisDeleteStoredResourcesParamsSchema])
+  .describe('redisCacheDeletionParamsSchema');
+//#endregion CacheDeletionParams

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -34,7 +34,6 @@ export const tilesDeletionParamsSchema = z
 //#endregion TilesDeletionParams
 
 //#region DeleteStoredResourcesParams
-/** Paths to delete recursively. */
 export const resourcePathsSchema = z.object({
   paths: z.array(z.string().min(1)).min(1),
 });

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -22,11 +22,11 @@ export const deleteTaskParamsSchema = z
 //#endregion DeleteTaskParams
 
 //#region TilesDeletionParams
-export const s3TilesDeletionParamsSchema = s3StorageSchema.merge(tilePyramidSchema);
+export const s3TilesDeletionParamsSchema = s3StorageSchema.merge(tilePyramidSchema).strict();
 
-export const fsTilesDeletionParamsSchema = fsStorageSchema.merge(tilePyramidSchema);
+export const fsTilesDeletionParamsSchema = fsStorageSchema.merge(tilePyramidSchema).strict();
 
-export const redisTilesDeletionParamsSchema = redisDeletionBaseSchema.merge(tileRangesSchema).strict(); // Reject path-store fields outright: a prefix store has no tilesPath
+export const redisTilesDeletionParamsSchema = redisDeletionBaseSchema.merge(tileRangesSchema).strict();
 
 export const tilesDeletionParamsSchema = z
   .discriminatedUnion('storageProvider', [s3TilesDeletionParamsSchema, fsTilesDeletionParamsSchema, redisTilesDeletionParamsSchema])

--- a/src/schemas/deletion/task.schema.ts
+++ b/src/schemas/deletion/task.schema.ts
@@ -55,16 +55,3 @@ export const deleteStoredResourcesParamsSchema = z
   ])
   .describe('deleteStoredResourcesParamsSchema');
 //#endregion DeleteStoredResourcesParams
-
-//#region CacheDeletionParams
-/**
- * Params of the single `cache-deletion` task. The two shapes are told apart by their
- * fields rather than by the task type: `ranges` present means range-based deletion,
- * `prefix` alone means a whole-layer wipe. Both members are `.strict()`, so at most
- * one can ever match — `ranges` is required on the first and rejected as an unknown
- * key by the second.
- */
-export const redisCacheDeletionParamsSchema = z
-  .union([redisTilesDeletionParamsSchema, redisDeleteStoredResourcesParamsSchema])
-  .describe('redisCacheDeletionParamsSchema');
-//#endregion CacheDeletionParams

--- a/src/types/core/storage.type.ts
+++ b/src/types/core/storage.type.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
-import type { fsStorageSchema, s3StorageSchema, storageSchema } from '../../schemas';
+import type { fsStorageSchema, redisStorageSchema, s3StorageSchema, storageSchema } from '../../schemas';
 
 export type FsStorage = z.infer<typeof fsStorageSchema>;
 export type S3Storage = z.infer<typeof s3StorageSchema>;
+export type RedisStorage = z.infer<typeof redisStorageSchema>;
 export type Storage = z.infer<typeof storageSchema>;

--- a/src/types/core/tile.type.ts
+++ b/src/types/core/tile.type.ts
@@ -1,5 +1,4 @@
 import z from 'zod';
-import { tileRangeSchema, tilesDeletionParamsSchema } from '../../schemas/core/tile.schema';
+import { tileRangeSchema } from '../../schemas/core/tile.schema';
 
-export type TilesDeletionParams = z.infer<typeof tilesDeletionParamsSchema>;
 export type TileRange = z.infer<typeof tileRangeSchema>;

--- a/src/types/deletion/task.type.ts
+++ b/src/types/deletion/task.type.ts
@@ -4,7 +4,6 @@ import {
   deleteTaskParamsSchema,
   fsDeleteStoredResourcesParamsSchema,
   fsTilesDeletionParamsSchema,
-  redisCacheDeletionParamsSchema,
   redisDeleteStoredResourcesParamsSchema,
   redisTilesDeletionParamsSchema,
   s3DeleteStoredResourcesParamsSchema,

--- a/src/types/deletion/task.type.ts
+++ b/src/types/deletion/task.type.ts
@@ -29,7 +29,3 @@ export type S3DeleteStoredResourcesParams = z.infer<typeof s3DeleteStoredResourc
 export type FsDeleteStoredResourcesParams = z.infer<typeof fsDeleteStoredResourcesParamsSchema>;
 export type RedisDeleteStoredResourcesParams = z.infer<typeof redisDeleteStoredResourcesParamsSchema>;
 //#endregion DeleteStoredResourcesParams
-
-//#region CacheDeletionParams
-export type RedisCacheDeletionParams = z.infer<typeof redisCacheDeletionParamsSchema>;
-//#endregion CacheDeletionParams

--- a/src/types/deletion/task.type.ts
+++ b/src/types/deletion/task.type.ts
@@ -1,5 +1,35 @@
 import z from 'zod';
-import { deleteTaskParamsSchema, deleteStoredResourcesParamsSchema } from '../../schemas/deletion/task.schema';
+import {
+  deleteStoredResourcesParamsSchema,
+  deleteTaskParamsSchema,
+  fsDeleteStoredResourcesParamsSchema,
+  fsTilesDeletionParamsSchema,
+  redisCacheDeletionParamsSchema,
+  redisDeleteStoredResourcesParamsSchema,
+  redisTilesDeletionParamsSchema,
+  s3DeleteStoredResourcesParamsSchema,
+  s3TilesDeletionParamsSchema,
+  tilesDeletionParamsSchema,
+} from '../../schemas/deletion/task.schema';
 
+//#region DeleteTaskParams
 export type DeleteTaskParams = z.infer<typeof deleteTaskParamsSchema>;
+//#endregion DeleteTaskParams
+
+//#region TilesDeletionParams
+export type TilesDeletionParams = z.infer<typeof tilesDeletionParamsSchema>;
+export type S3TilesDeletionParams = z.infer<typeof s3TilesDeletionParamsSchema>;
+export type FsTilesDeletionParams = z.infer<typeof fsTilesDeletionParamsSchema>;
+export type RedisTilesDeletionParams = z.infer<typeof redisTilesDeletionParamsSchema>;
+//#endregion TilesDeletionParams
+
+//#region DeleteStoredResourcesParams
 export type DeleteStoredResourcesParams = z.infer<typeof deleteStoredResourcesParamsSchema>;
+export type S3DeleteStoredResourcesParams = z.infer<typeof s3DeleteStoredResourcesParamsSchema>;
+export type FsDeleteStoredResourcesParams = z.infer<typeof fsDeleteStoredResourcesParamsSchema>;
+export type RedisDeleteStoredResourcesParams = z.infer<typeof redisDeleteStoredResourcesParamsSchema>;
+//#endregion DeleteStoredResourcesParams
+
+//#region CacheDeletionParams
+export type RedisCacheDeletionParams = z.infer<typeof redisCacheDeletionParamsSchema>;
+//#endregion CacheDeletionParams


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| New feature     | ✔                                                                        |
| Breaking change | ✔                                                                        |

## What

Consolidates the deletion schemas around a single `storageProvider` discriminator, and adds Redis as a storage provider so a layer's Redis-backed tile cache can be deleted through the same shapes as FS and S3.

## Why

Tile deletion and stored-resource deletion each handled providers their own way — tiles keyed on `sourceProvider`, stored resources on an intersection with `storageSchema`. Adding Redis to both would have meant duplicating that logic twice. Instead there is now one discriminator, with each provider's params composed from small reusable pieces.

## Changes

- **`StorageProvider`** (`FS | S3 | REDIS`) becomes the storage discriminator, replacing `SourceType`. It is deliberately not spread from `SourceType`, which also contains `GPKG` — a source format rather than a storage backend, and one that no storage schema accepts.
- **`redisStorageSchema`** joins `storageSchema`, located by a Redis key prefix.
- **Tile schemas split into composable parts:** `tileRangesSchema` (which tiles) and `tilesInfoSchema` (`tilesRelativePath` + `fileExtension`, meaningful only for path-based stores), combined as `tilePyramidSchema`.
- **Both deletion param schemas are now discriminated unions** over `storageProvider` with an S3 / FS / Redis member each, and each member is exported as its own type.
- **The two Redis shapes share a base** carrying the prefix plus an optional `delaySeconds`, to wait out a mapproxy reload before the keys are removed. Both are `.strict()`, so path-store fields such as `paths` are rejected outright rather than silently stripped — for a key-value store the prefix *is* the locator.
- **`Cache_Deletion` job type and `cache-deletion` task type** added.

## Also included: an import-cycle fix

`constants/export/constants.ts` imported `pickEnum` through the `utils` barrel, which pulls in `layer.utils` → the `schemas` barrel while `constants` is still initializing. As a result **9 of 11 schema modules threw `Cannot access '<x>' before initialization` when imported directly** — only the package entry point worked, because it happens to load `utils` first. It now imports the module directly, matching what `constants/core/constants.ts` already did. All 11 modules load.

This is why the package currently has no schema tests: a spec importing any schema module hits the cycle.

## Breaking changes

- Tiles deletion discriminator renamed: `sourceProvider` → `storageProvider`
- Field renamed: `tilesPath` → `tilesRelativePath`
- `tilesDeletionParamsSchema` / `TilesDeletionParams` moved from the core scope to deletion
- Removed: `tilesDeletionParamsBaseSchema`, `deleteStoredResourcesParamsBaseSchema`